### PR TITLE
fix: clear stale .next/dev types before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node -e \"require('fs').rmSync('.next/dev', { recursive: true, force: true })\"",
     "build": "next build",
     "start": "next start",
     "db:generate": "drizzle-kit generate",


### PR DESCRIPTION
## Summary

Local `npm run build` was reliably failing with:

```
Type error: Cannot find module '../../../app/page.js' or its corresponding type declarations.
.next/types/... const handler = {} as typeof import("../../../app/page.js")
```

Root cause: `tsconfig.json` includes `.next/dev/types/**/*.ts`, and `next build` type-checks those files. But `.next/dev/types` is only (re)generated by `next dev`, never by `next build`. After the app moved from root `app/` to `src/app/`, a **stale** `.next/dev/types/validator.ts` kept importing `../../../app/page.js` (the old location), so every subsequent local build failed until `.next` was manually deleted.

This never affects clean checkouts / CI / Vercel (no pre-existing `.next`), but bites repeated local builds (e.g. the daily maintenance routine).

## Fix

Add a portable, dependency-free `prebuild` script that removes the stale `.next/dev` directory before building:

```json
"prebuild": "node -e \"require('fs').rmSync('.next/dev', { recursive: true, force: true })\""
```

- `next build` never writes `.next/dev`, so this is safe and the build cache in `.next/cache` is preserved.
- Cross-platform (uses Node's `fs.rmSync`, no `rm -rf`).

## Test plan

- [x] Reproduced the failure by planting a stale `.next/dev/types/validator.ts` importing `../../../app/page.js`
- [x] `npm run build` now removes the stale dir via `prebuild` and completes successfully
- [x] Confirmed `next build` does not recreate `.next/dev` (build cache untouched)